### PR TITLE
feat: initial audio decoding support

### DIFF
--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -17,6 +17,7 @@ import { CommandTimedOutError, PermissionDeniedError } from './errors';
 vi.mock('./mumble-socket', () => ({
   MumbleSocket: vi.fn().mockImplementation(() => ({
     packet: new Subject(),
+    audioPacket: new Subject(),
     send: vi.fn().mockResolvedValue({}),
     end: vi.fn(),
   })),

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,5 +1,6 @@
 import { Channel, ChannelChanges } from './channel';
 import { MumbleSocket } from './mumble-socket';
+import { SpeakingStateChange } from './speaking-state-change';
 import { User, UserChanges } from './user';
 
 // FIXME This _has_ to be type alias instead of interface.
@@ -16,4 +17,6 @@ export type Events = {
   userCreate: (user: User) => void;
   userUpdate: (user: User, changes: UserChanges) => void;
   userRemove: (user: User) => void;
+
+  speakingStateChange: (stateChange: SpeakingStateChange) => void;
 };

--- a/src/read-varint.spec.ts
+++ b/src/read-varint.spec.ts
@@ -1,0 +1,45 @@
+import { readVarint } from './read-varint';
+
+describe('readVarint', () => {
+  it('should read 7-bit positive number', () => {
+    expect(readVarint(Buffer.from([0x5]))).toStrictEqual({
+      value: 0x5,
+      length: 1,
+    });
+  });
+
+  it('should read 14-bit positive number', () => {
+    expect(readVarint(Buffer.from([0b10000111, 0b00101000]))).toStrictEqual({
+      value: 1832,
+      length: 2,
+    });
+  });
+
+  it('should read 21-bit positive number', () => {
+    expect(
+      readVarint(Buffer.from([0b11011100, 0b00101011, 0b11100110])),
+    ).toStrictEqual({
+      value: 1846246,
+      length: 3,
+    });
+  });
+
+  it('should read 28-bit positive number', () => {
+    expect(
+      readVarint(Buffer.from([0b11100100, 0b11101110, 0b11100011, 0b01010000])),
+    ).toStrictEqual({
+      value: 82764624,
+      length: 4,
+    });
+  });
+
+  it('should read 32-bit positive number', () => {
+    expect(
+      readVarint(
+        Buffer.from([
+          0b11110000, 0b00110001, 0b01010100, 0b11100001, 0b00100011,
+        ]),
+      ),
+    ).toStrictEqual({ value: 827646243, length: 5 });
+  });
+});

--- a/src/read-varint.ts
+++ b/src/read-varint.ts
@@ -1,0 +1,62 @@
+export function readVarint(buffer: Buffer): {
+  value: number | bigint;
+  length: number;
+} {
+  // https://github.com/mumble-voip/mumble/blob/master/docs/dev/network-protocol/voice_data.md#variable-length-integer-encoding
+  switch (true) {
+    case (0b10000000 & buffer[0]) === 0:
+      // 7-bit positive number
+      return { value: buffer.readUInt8(0), length: 1 };
+
+    case (0b11000000 & buffer[0]) === 0b10000000:
+      // 14-bit positive number
+      return { value: buffer.readUint16BE(0) & 0x3fff, length: 2 };
+
+    case (0b11100000 & buffer[0]) === 0b11000000:
+      // 21-bit positive number
+      return {
+        value: ((buffer.readUint16BE(0) & 0x1fff) << 8) | buffer.readUint8(2),
+        length: 3,
+      };
+
+    case (0b11110000 & buffer[0]) === 0b11100000:
+      // 28-bit positive number
+      return {
+        value: buffer.readUint32BE(0) & 0x1fffffff,
+        length: 4,
+      };
+
+    case (0b11111100 & buffer[0]) === 0b11110000:
+      // 32-bit positive number
+      return {
+        value: buffer.readUint32BE(1),
+        length: 5,
+      };
+
+    case (0b11111100 & buffer[0]) === 0b11110100:
+      // 64-bit number
+      return {
+        value: buffer.readBigInt64BE(1),
+        length: 9,
+      };
+
+    case (0b11111100 & buffer[0]) === 0b11111000: {
+      // Negative recursive varint
+      const { value, length } = readVarint(buffer.subarray(1));
+      return {
+        value: -value,
+        length: length + 1,
+      };
+    }
+
+    case (0b11111100 & buffer[0]) === 0b11111100:
+      // Byte-inverted negative two bit number (~xx)
+      return {
+        value: ~(buffer.readUint8(0) & 0x00000011),
+        length: 1,
+      };
+
+    default:
+      throw new Error(`varint not supported`);
+  }
+}

--- a/src/speaking-state-change.ts
+++ b/src/speaking-state-change.ts
@@ -1,0 +1,6 @@
+import { User } from './user';
+
+export interface SpeakingStateChange {
+  user: User;
+  speaking: boolean;
+}


### PR DESCRIPTION
This is an initial implementation of handling audio packets. It supports only normal talking (i.e. no whispering) and doesn't actually decode audio - just monitors when a user starts and ends speaking.

Usage:
```js
client.on('speakingStateChange', state => {
  console.log(`${state.user.name} is ${!state.speaking ? 'not ' : ''}speaking`);
});
```

Solves #776 