### PR TITLE
fix: reject connect() when the server drops the connection

### DIFF
--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -13,7 +13,11 @@ import { Client } from './client';
 import { MumbleSocket } from './mumble-socket';
 import { PacketType } from './packet-type';
 import { MockedObject } from 'vitest';
-import { CommandTimedOutError, PermissionDeniedError } from './errors';
+import {
+  ClientDisconnectedError,
+  CommandTimedOutError,
+  PermissionDeniedError,
+} from './errors';
 
 vi.mock('./mumble-socket', () => ({
   MumbleSocket: vi.fn().mockImplementation(function () {
@@ -121,6 +125,22 @@ describe(Client.name, () => {
 
   it('should create client', () => {
     expect(client).toBeTruthy();
+  });
+
+  it('should reject when the server closes the connection during the handshake', async () => {
+    client.on('socketConnect', s => {
+      const socket = vi.mocked(s) as MockSocket;
+      socket.send.mockImplementation(type => {
+        // server drops the TLS connection instead of sending a Reject packet
+        // (mumble 1.6.x behavior on failed superuser auth)
+        if (type.typeName === Authenticate.typeName) {
+          socket.packet.complete();
+        }
+        return Promise.resolve();
+      });
+    });
+
+    await expect(client.connect()).rejects.toThrow(ClientDisconnectedError);
   });
 
   describe('when connected', () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -16,6 +16,7 @@ import {
   takeUntil,
   tap,
   throwError,
+  throwIfEmpty,
   timeout,
   zip,
 } from 'rxjs';
@@ -215,6 +216,11 @@ export class Client extends TypedEventEmitter<Events, Events> {
             throwError(() => new ConnectionRejectedError(reject)),
           ),
         ),
+      ).pipe(
+        // the packet observable completes when the server closes the
+        // connection without sending a Reject packet (e.g. mumble 1.6.x on
+        // failed superuser auth)
+        throwIfEmpty(() => new ClientDisconnectedError()),
       ),
     );
 

--- a/src/mumble-socket.spec.ts
+++ b/src/mumble-socket.spec.ts
@@ -1,0 +1,19 @@
+import { EventEmitter } from 'events';
+import { TLSSocket } from 'tls';
+import { MumbleSocket } from './mumble-socket';
+
+describe(MumbleSocket.name, () => {
+  it('should complete packet observables when the socket closes', () => {
+    const tlsSocket = new EventEmitter() as unknown as TLSSocket;
+    const socket = new MumbleSocket(tlsSocket);
+
+    const complete = vi.fn();
+    socket.packet.subscribe({ complete });
+    socket.audioPacket.subscribe({ complete });
+    socket.fullAudioPacket.subscribe({ complete });
+
+    tlsSocket.emit('close');
+
+    expect(complete).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/mumble-socket.ts
+++ b/src/mumble-socket.ts
@@ -54,6 +54,13 @@ export class MumbleSocket {
     this.socket.on('data', (data: Buffer) => {
       this.receiveData(data);
     });
+    // 'close' fires after both 'end' and 'error'; completing the subjects
+    // lets pending lastValueFrom() calls reject instead of hanging forever
+    this.socket.on('close', () => {
+      this._packet.complete();
+      this._audioPacket.complete();
+      this._fullAudioPacket.complete();
+    });
     this.readPrefix();
   }
 


### PR DESCRIPTION
## Problem

`client.connect()` hangs indefinitely when the server closes the TLS connection without sending a protocol-level `Reject` packet — which is exactly what Mumble 1.6.x does when superuser password auth fails.

`MumbleSocket` only registered a `'data'` handler and never terminated its internal packet Subjects, so the `race(zip(ServerSync, ServerConfig, Version), Reject)` inside `connect()` never produced a value and `lastValueFrom()` waited forever.

## Fix

- `MumbleSocket` now listens for `'close'` on the underlying TLS socket (which fires after both `'end'` and `'error'`) and completes `_packet`, `_audioPacket` and `_fullAudioPacket`. Completing rather than erroring keeps the existing no-error-callback `packet.subscribe(...)` call sites safe from unhandled RxJS errors.
- `connect()` pipes the race through `throwIfEmpty(() => new ClientDisconnectedError())`, so callers get a meaningful rejection instead of a cryptic `EmptyError`.

## Verification

Against a local TLS server that accepts the handshake and then destroys the socket 100 ms after receiving the first client bytes (simulating the 1.6.x failed-auth drop):

- before: `connect()` still hanging after 5 s
- after: `connect()` rejects in ~122 ms with `ClientDisconnectedError`

Unit tests added for both layers (`mumble-socket.spec.ts`, `client.spec.ts`); all 37 tests pass. The pre-existing eslint/tsc findings on master are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)